### PR TITLE
PHPをDockerで動かせるようにしました

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 .pl linguist-language=Perl
+
+#windowsで開発したときに改行コードがCRLFにならないようにする
+* text=auto eol=lf

--- a/docker-compose.perl.yml
+++ b/docker-compose.perl.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  bbs:
+    build:
+      context: .
+      dockerfile: ./docker/perl/Dockerfile
+    ports:
+      - "8080:80"

--- a/docker-compose.php.yml
+++ b/docker-compose.php.yml
@@ -1,9 +1,9 @@
 version: '3'
 
 services:
-  bbs-perl:
+  bbs-php:
     build:
       context: .
-      dockerfile: ./docker/perl/Dockerfile
+      dockerfile: ./docker/php/Dockerfile
     ports:
       - "8080:80"

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,3 +10,14 @@ $ docker-compose -f docker-compose.perl.yml up
 $ docker-compose -f docker-compose.perl.yml up --build
 ```
 ブラウザで[http://localhost:8080/test/admin.cgi](http://localhost:8080/test/admin.cgi)にアクセスして、その後は`Readme.txt`に従ってください。
+
+### PHP版
+プロジェクトのルートディレクトリで以下のコマンドを実行することでDocker上で掲示板を動かせます。
+```
+$ docker-compose -f docker-compose.php.yml up
+```
+
+ソースコードを変更した際は、以下のコマンドを実行してください。
+```
+$ docker-compose -f docker-compose.php.yml up --build
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,14 +1,12 @@
 ## 使い方
 ### Perl版
-プロジェクトのルートディレクトリで以下のコマンドを実行してDockerイメージを作成してください。
+プロジェクトのルートディレクトリで以下のコマンドを実行することでDocker上で掲示板を動かせます。
 ```
-$ docker build -t 0ch_plus -f Dockerfile_perl .
-```
-
-次に以下のコマンドでイメージからコンテナを作成して掲示板を動かすことができます。ホスト側でリッスンするポート番号を変更したい場合は、`8080`の部分を書き換えて下さい。
-```
-$ docker run -p 8080:80 0ch_plus
+$ docker-compose -f docker-compose.perl.yml up
 ```
 
+ソースコードを変更した際は、以下のコマンドを実行してください。
+```
+$ docker-compose -f docker-compose.perl.yml up --build
+```
 ブラウザで[http://localhost:8080/test/admin.cgi](http://localhost:8080/test/admin.cgi)にアクセスして、その後は`Readme.txt`に従ってください。
-

--- a/docker/perl/Dockerfile
+++ b/docker/perl/Dockerfile
@@ -6,17 +6,16 @@ RUN apt update && apt install libcgi-session-perl libwww-perl -y
 #apacheの設定を転送
 COPY ./docker/perl/httpd.conf /usr/local/apache2/conf/
 
+#ルートパスで表示させるhtmlを転送
+COPY ./docker/perl/index.html /usr/local/apache2/htdocs/
+
+RUN chmod 707 /usr/local/apache2/htdocs/
+
 #testディレクトリ下のファイルを転送
 COPY ./test /usr/local/apache2/htdocs/test/
 
 #パーミッションを設定するためのシェルスクリプトを転送
 COPY ./docker/perl/permission.sh /home/
-
-#ルートパスで表示させるhtmlを転送
-COPY ./docker/perl/index.html /usr/local/apache2/htdocs/
-
-#windowsの改行コードをlinuxのものに変換
-RUN find /usr/local/apache2/htdocs/test/ -type f | xargs sed -i 's/\r//g'
 
 #パーミッションを設定
 RUN /home/permission.sh

--- a/docker/php/000-default.conf
+++ b/docker/php/000-default.conf
@@ -1,0 +1,34 @@
+# 公開ルートディレクトリの設定ファイル
+
+<VirtualHost *:80>
+        # The ServerName directive sets the request scheme, hostname and port that
+        # the server uses to identify itself. This is used when creating
+        # redirection URLs. In the context of virtual hosts, the ServerName
+        # specifies what hostname must appear in the request's Host: header to
+        # match this virtual host. For the default virtual host (this file) this
+        # value is not decisive as it is used as a last resort host regardless.
+        # However, you must set it for any further virtual host explicitly.
+        #ServerName www.example.com
+
+        ServerAdmin webmaster@localhost
+        DocumentRoot /var/www/html
+
+        Options +ExecCGI +FollowSymLinks
+        AddHandler php-script .php .cgi
+
+        # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+        # error, crit, alert, emerg.
+        # It is also possible to configure the loglevel for particular
+        # modules, e.g.
+        #LogLevel info ssl:warn
+
+        ErrorLog ${APACHE_LOG_DIR}/error.log
+        CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+        # For most configuration files from conf-available/, which are
+        # enabled or disabled at a global level, it is possible to
+        # include a line for only one particular virtual host. For example the
+        # following line enables the CGI configuration for this host only
+        # after it has been globally disabled with "a2disconf".
+        #Include conf-available/serve-cgi-bin.conf
+</VirtualHost>

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,0 +1,4 @@
+FROM php:8.2-apache
+
+COPY ./PHP/test /var/www/html/test
+COPY ./docker/php/000-default.conf /etc/apache2/sites-available/000-default.conf


### PR DESCRIPTION
変更点
- Docker Composeを使うように変更
- Windowsで開発したときに改行コードがCRLFにならないように```.gitattributes```を変更
- PHPをDockerで動かせるように
- ```docker/README.md```をDocker composeとPHP用に変更

